### PR TITLE
Added support for inclusive namespaces

### DIFF
--- a/canonix.gemspec
+++ b/canonix.gemspec
@@ -8,8 +8,8 @@ Gem::Specification.new do |s|
   s.version = "0.1.1"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
-  s.authors = [%q{Brendon Muir}]
-  s.date = %q{2011-06-16}
+  s.authors = ["Brendon Muir"]
+  s.date = %q{2011-06-28}
   s.description = %q{This is based on andrewferk's rewrite for Ruby 1.9 compatibility, but applies 
       relevance's fix to ensure proper canonicalisation. It is intended that this be the new official 
       Ruby Canonicaliser as the other project seems to be abandoned.}
@@ -32,12 +32,14 @@ Gem::Specification.new do |s|
     "test/helper.rb",
     "test/saml_assertion.xml",
     "test/saml_expected_canonical_form.xml",
+    "test/saml_with_inclusive_ns_assertion.xml",
+    "test/saml_with_inclusive_ns_expected_canonical_form.xml",
     "test/test_xmlcanonicalizer.rb",
     "tests.watchr"
   ]
   s.homepage = %q{http://github.com/brendon/canonix}
-  s.require_paths = [%q{lib}]
-  s.rubygems_version = %q{1.8.5}
+  s.require_paths = ["lib"]
+  s.rubygems_version = %q{1.5.0}
   s.summary = %q{XML Canonicalizer for Ruby >= 1.92}
 
   if s.respond_to? :specification_version then

--- a/lib/xml/util/xmlcanonicalizer.rb
+++ b/lib/xml/util/xmlcanonicalizer.rb
@@ -86,7 +86,7 @@ module XML
       end
       
       class XmlCanonicalizer
-        attr_accessor :prefix_list, :logger
+        attr_accessor :prefix_list, :logger, :inclusive_namespaces
         
         BEFORE_DOC_ELEMENT = 0
         INSIDE_DOC_ELEMENT = 1
@@ -228,17 +228,14 @@ module XML
           if (visible && !has_empty_namespace && !is_namespace_rendered(nil, nil)) 
             @res = @res + ' xmlns=""'
           end
-          #TODO: ns of inclusive_list
-#=begin
-          if ((@prefix_list) && (node.to_s() == node.parent().to_s()))
-            #list.push(node.prefix())
-            @inclusive_namespaces.each{|ns|
-              prefix = ns.prefix().split(":")[1]
-              list.push(prefix) if (!list.include?(prefix) && (!node.attributes.prefixes.include?(prefix))) 
+          
+          #: ns of inclusive_list
+          if !self.inclusive_namespaces.empty?
+            self.inclusive_namespaces.each{|prefix|
+              list.push(prefix) if (!list.include?(prefix) && (node.attributes.prefixes.include?(prefix))) 
             }
-				@prefix_list = nil
           end
-#=end
+          
           list.sort!()
           list.each{|prefix|
             next if (prefix == "")

--- a/lib/xml/util/xmlcanonicalizer.rb
+++ b/lib/xml/util/xmlcanonicalizer.rb
@@ -108,7 +108,7 @@ module XML
           @prevVisibleNamespacesStart = 0
           @prevVisibleNamespacesEnd = 0
           @visibleNamespaces = Array.new()
-			 @inclusive_namespaces = Array.new()
+			    @inclusive_namespaces = Array.new()
           @prefix_list = nil
         end
         

--- a/lib/xml/util/xmlcanonicalizer.rb
+++ b/lib/xml/util/xmlcanonicalizer.rb
@@ -108,8 +108,6 @@ module XML
           @prevVisibleNamespacesStart = 0
           @prevVisibleNamespacesEnd = 0
           @visibleNamespaces = Array.new()
-			    @inclusive_namespaces = Array.new()
-          @prefix_list = nil
         end
         
         def add_inclusive_namespaces(prefix_list, element, visible_namespaces)
@@ -127,22 +125,6 @@ module XML
         end
         
         def canonicalize(document)
-          write_document_node(document)
-          @res
-        end
-        
-        def canonicalize_element(element, logging = true)
-          @inclusive_namespaces = add_inclusive_namespaces(@prefix_list, element, @inclusive_namespaces) if (@prefix_list)
-          @preserve_document = element.document()
-          tmp_parent = element.parent()
-          body_string = remove_whitespace(element.to_s().gsub("\n","").gsub("\t","").gsub("\r",""))
-          document = Document.new(body_string)
-          tmp_parent.delete_element(element)
-          element = tmp_parent.add_element(document.root())
-          @preserve_element = element
-          document = Document.new(element.to_s())
-          ns = element.namespace(element.prefix())
-          document.root().add_namespace(element.prefix(), ns)
           write_document_node(document)
           @res
         end
@@ -230,7 +212,7 @@ module XML
           end
           
           #: ns of inclusive_list
-          if !self.inclusive_namespaces.empty?
+          if self.inclusive_namespaces && !self.inclusive_namespaces.empty?
             self.inclusive_namespaces.each{|prefix|
               list.push(prefix) if (!list.include?(prefix) && (node.attributes.prefixes.include?(prefix))) 
             }
@@ -399,23 +381,8 @@ if __FILE__ == $0
   document = Document.new(File.new(ARGV[0]))
   body = nil
   c = WSS4R::Security::Util::XmlCanonicalizer.new(false, true)
-  
-  if (ARGV.size() == 3) 
-    body = ARGV[2]
-    if (body == "true")
-      element = XPath.match(document, "/soap:Envelope/soap:Body")[0]
-      element = XPath.first(document, "/soap:Envelope/soap:Header/wsse:Security/Signature/SignedInfo")
-      result = c.canonicalize_element(element)
-      puts("-----")
-      puts(result)
-      puts("-----")
-      puts(result.size())			
-      puts("-----")
-      puts(CryptHash.new().digest_b64(result))
-    end
-  else 
-    result = c.canonicalize(document)
-  end
+    
+  result = c.canonicalize(document)
   
   file = File.new(ARGV[1], "wb")
   file.write(result)

--- a/test/saml_with_inclusive_ns_assertion.xml
+++ b/test/saml_with_inclusive_ns_assertion.xml
@@ -1,0 +1,39 @@
+<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" Version="2.0" Destination="http://dev.example.com:8080/sessions/saml" ID="_400c66cfbb96b81e87d6bc96fefdb9b01308849650183" InResponseTo="_107c07d0-7feb-012e-8cc0-001ec2c1cafd" IssueInstant="2011-06-23T17:20:50.183Z">
+  <saml:Issuer xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Format="urn:oasis:names:tc:SAML:2.0:nameid-format:entity">http://dev.example.com:8080/sessions/saml</saml:Issuer>
+  <samlp:Status>
+    <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+  </samlp:Status>
+  <saml:Assertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Version="2.0" ID="_b197baba4544550444357b2b18de57961308849650183" IssueInstant="2011-06-23T17:20:50.183Z">
+    <saml:Issuer Format="urn:oasis:names:tc:SAML:2.0:nameid-format:entity">http://dev.example.com:8080/sessions/saml</saml:Issuer>
+    <saml:Subject>
+      <saml:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified">mail@example.com</saml:NameID>
+      <saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+        <saml:SubjectConfirmationData InResponseTo="_107c07d0-7feb-012e-8cc0-001ec2c1cafd" NotOnOrAfter="2011-06-23T17:25:50.183Z" Recipient="http://bmls.screenstepslive.dev/sessions/saml"/>
+      </saml:SubjectConfirmation>
+    </saml:Subject>
+    <saml:Conditions NotOnOrAfter="2011-06-23T17:25:50.183Z" NotBefore="2011-06-23T17:20:50.183Z">
+      <saml:AudienceRestriction>
+        <saml:Audience>Audience</saml:Audience>
+      </saml:AudienceRestriction>
+    </saml:Conditions>
+    <saml:AuthnStatement AuthnInstant="2011-06-23T17:20:50.183Z">
+      <saml:AuthnContext>
+        <saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:unspecified</saml:AuthnContextClassRef>
+      </saml:AuthnContext>
+    </saml:AuthnStatement>
+    <saml:AttributeStatement>
+      <saml:Attribute Name="userId" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified">
+        <saml:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema" xsi:type="xs:anyType">00550000001b7Kf</saml:AttributeValue>
+      </saml:Attribute>
+      <saml:Attribute Name="username" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified">
+        <saml:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema" xsi:type="xs:anyType">mail@example.com</saml:AttributeValue>
+      </saml:Attribute>
+      <saml:Attribute Name="email" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified">
+        <saml:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema" xsi:type="xs:anyType">mail@example.com</saml:AttributeValue>
+      </saml:Attribute>
+      <saml:Attribute Name="is_portal_user" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified">
+        <saml:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema" xsi:type="xs:anyType">false</saml:AttributeValue>
+      </saml:Attribute>
+    </saml:AttributeStatement>
+  </saml:Assertion>
+</samlp:Response>

--- a/test/saml_with_inclusive_ns_expected_canonical_form.xml
+++ b/test/saml_with_inclusive_ns_expected_canonical_form.xml
@@ -1,0 +1,39 @@
+<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" Destination="http://dev.example.com:8080/sessions/saml" ID="_400c66cfbb96b81e87d6bc96fefdb9b01308849650183" InResponseTo="_107c07d0-7feb-012e-8cc0-001ec2c1cafd" IssueInstant="2011-06-23T17:20:50.183Z" Version="2.0">
+  <saml:Issuer xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Format="urn:oasis:names:tc:SAML:2.0:nameid-format:entity">http://dev.example.com:8080/sessions/saml</saml:Issuer>
+  <samlp:Status>
+    <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"></samlp:StatusCode>
+  </samlp:Status>
+  <saml:Assertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="_b197baba4544550444357b2b18de57961308849650183" IssueInstant="2011-06-23T17:20:50.183Z" Version="2.0">
+    <saml:Issuer Format="urn:oasis:names:tc:SAML:2.0:nameid-format:entity">http://dev.example.com:8080/sessions/saml</saml:Issuer>
+    <saml:Subject>
+      <saml:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified">mail@example.com</saml:NameID>
+      <saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+        <saml:SubjectConfirmationData InResponseTo="_107c07d0-7feb-012e-8cc0-001ec2c1cafd" NotOnOrAfter="2011-06-23T17:25:50.183Z" Recipient="http://bmls.screenstepslive.dev/sessions/saml"></saml:SubjectConfirmationData>
+      </saml:SubjectConfirmation>
+    </saml:Subject>
+    <saml:Conditions NotBefore="2011-06-23T17:20:50.183Z" NotOnOrAfter="2011-06-23T17:25:50.183Z">
+      <saml:AudienceRestriction>
+        <saml:Audience>Audience</saml:Audience>
+      </saml:AudienceRestriction>
+    </saml:Conditions>
+    <saml:AuthnStatement AuthnInstant="2011-06-23T17:20:50.183Z">
+      <saml:AuthnContext>
+        <saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:unspecified</saml:AuthnContextClassRef>
+      </saml:AuthnContext>
+    </saml:AuthnStatement>
+    <saml:AttributeStatement>
+      <saml:Attribute Name="userId" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified">
+        <saml:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:anyType">00550000001b7Kf</saml:AttributeValue>
+      </saml:Attribute>
+      <saml:Attribute Name="username" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified">
+        <saml:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:anyType">mail@example.com</saml:AttributeValue>
+      </saml:Attribute>
+      <saml:Attribute Name="email" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified">
+        <saml:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:anyType">mail@example.com</saml:AttributeValue>
+      </saml:Attribute>
+      <saml:Attribute Name="is_portal_user" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified">
+        <saml:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:anyType">false</saml:AttributeValue>
+      </saml:Attribute>
+    </saml:AttributeStatement>
+  </saml:Assertion>
+</samlp:Response>

--- a/test/test_xmlcanonicalizer.rb
+++ b/test/test_xmlcanonicalizer.rb
@@ -55,7 +55,7 @@ class TestXmlcanonicalizer < Test::Unit::TestCase
     assert_equal xml_expect, xml_canonicalized
   end
   
-  should "canonicalize a saml file from salesforce" do
+  should "canonicalize a saml file with inclusive namespaces" do
     fp = File.new(File.dirname(File.expand_path(__FILE__))+'/saml_with_inclusive_ns_assertion.xml','r')
     xml = ''
     while (l = fp.gets)

--- a/test/test_xmlcanonicalizer.rb
+++ b/test/test_xmlcanonicalizer.rb
@@ -54,5 +54,27 @@ class TestXmlcanonicalizer < Test::Unit::TestCase
     
     assert_equal xml_expect, xml_canonicalized
   end
+  
+  should "canonicalize a saml file from salesforce" do
+    fp = File.new(File.dirname(File.expand_path(__FILE__))+'/saml_with_inclusive_ns_assertion.xml','r')
+    xml = ''
+    while (l = fp.gets)
+      xml += l
+    end
+    fp.close
+    
+    xml_canonicalizer = XML::Util::XmlCanonicalizer.new(false,true)
+    rexml = REXML::Document.new(xml);
+    xml_canonicalizer.inclusive_namespaces = %w(ds saml samlp xs)
+    xml_canonicalized = xml_canonicalizer.canonicalize(rexml);
+    
+    fp = File.new(File.dirname(File.expand_path(__FILE__))+'/saml_with_inclusive_ns_expected_canonical_form.xml','r')
+    xml_expect = ''
+    while (l = fp.gets)
+      xml_expect += l
+    end
+    fp.close
+    assert_equal xml_expect, xml_canonicalized #, (xml_canonicalized.to_s + "\n\n" + xml_expect)
+  end
 
 end


### PR DESCRIPTION
I working on getting the ruby-saml gem to play nicely with Salesforce. Salesforce SAML assertions use inclusive namespaces so I had to add support to the canonix gem for this. I have included inclusive namespace support as well as some additional tests for verify the update.

Thanks,
Greg DeVore
